### PR TITLE
feat: add global exception handler

### DIFF
--- a/src/main/java/com/eccolimp/cacamba_manager/controller/api/NotificationController.java
+++ b/src/main/java/com/eccolimp/cacamba_manager/controller/api/NotificationController.java
@@ -24,14 +24,9 @@ public class NotificationController {
      */
     @PostMapping("/test")
     public ResponseEntity<String> testarNotificacao(@RequestParam String email) {
-        try {
-            log.info("Testando envio de notificação para: {}", email);
-            notificationService.testarNotificacao(email);
-            return ResponseEntity.ok("Email de teste enviado com sucesso para: " + email);
-        } catch (Exception e) {
-            log.error("Erro ao enviar email de teste", e);
-            return ResponseEntity.badRequest().body("Erro ao enviar email: " + e.getMessage());
-        }
+        log.info("Testando envio de notificação para: {}", email);
+        notificationService.testarNotificacao(email);
+        return ResponseEntity.ok("Email de teste enviado com sucesso para: " + email);
     }
 
     /**
@@ -39,14 +34,9 @@ public class NotificationController {
      */
     @PostMapping("/vencimento/forcar")
     public ResponseEntity<String> forcarNotificacoesVencimento() {
-        try {
-            log.info("Forçando envio de notificações de vencimento");
-            notificationService.enviarNotificacoesVencimento();
-            return ResponseEntity.ok("Notificações de vencimento enviadas com sucesso");
-        } catch (Exception e) {
-            log.error("Erro ao enviar notificações de vencimento", e);
-            return ResponseEntity.badRequest().body("Erro ao enviar notificações: " + e.getMessage());
-        }
+        log.info("Forçando envio de notificações de vencimento");
+        notificationService.enviarNotificacoesVencimento();
+        return ResponseEntity.ok("Notificações de vencimento enviadas com sucesso");
     }
 
     /**
@@ -54,13 +44,8 @@ public class NotificationController {
      */
     @PostMapping("/relatorio/forcar")
     public ResponseEntity<String> forcarRelatorioSemanal() {
-        try {
-            log.info("Forçando envio de relatório semanal");
-            notificationService.enviarRelatorioSemanal();
-            return ResponseEntity.ok("Relatório semanal enviado com sucesso");
-        } catch (Exception e) {
-            log.error("Erro ao enviar relatório semanal", e);
-            return ResponseEntity.badRequest().body("Erro ao enviar relatório: " + e.getMessage());
-        }
+        log.info("Forçando envio de relatório semanal");
+        notificationService.enviarRelatorioSemanal();
+        return ResponseEntity.ok("Relatório semanal enviado com sucesso");
     }
-} 
+}

--- a/src/main/java/com/eccolimp/cacamba_manager/controller/api/RestExceptionHandler.java
+++ b/src/main/java/com/eccolimp/cacamba_manager/controller/api/RestExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.eccolimp.cacamba_manager.controller.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.eccolimp.cacamba_manager.domain.service.exception.BusinessException;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice
+@Slf4j
+public class RestExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<String> handleBusinessException(BusinessException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<String> handleEntityNotFoundException(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGenericException(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("Ocorreu um erro inesperado: " + ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- add RestExceptionHandler to map BusinessException, EntityNotFoundException and generic errors
- simplify NotificationController by removing redundant try/catch blocks

## Testing
- `mvn -q test` (fails: Non-resolvable parent POM - Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_6892304f045883219fbfae2d09a7e010