### PR TITLE
Adiciona validações ao CacambaDTO e teste de controller

### DIFF
--- a/src/main/java/com/eccolimp/cacamba_manager/dto/CacambaDTO.java
+++ b/src/main/java/com/eccolimp/cacamba_manager/dto/CacambaDTO.java
@@ -1,5 +1,13 @@
 package com.eccolimp.cacamba_manager.dto;
 
 import com.eccolimp.cacamba_manager.domain.model.StatusCacamba;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
-public record CacambaDTO(Long id, String codigo, Integer capacidadeM3, StatusCacamba status) {}
+public record CacambaDTO(
+        Long id,
+        @NotBlank @Size(max = 10) String codigo,
+        @NotNull @Min(1) Integer capacidadeM3,
+        StatusCacamba status) {}

--- a/src/test/java/com/eccolimp/cacamba_manager/CacambaControllerValidationTest.java
+++ b/src/test/java/com/eccolimp/cacamba_manager/CacambaControllerValidationTest.java
@@ -1,0 +1,40 @@
+package com.eccolimp.cacamba_manager;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.eccolimp.cacamba_manager.controller.api.CacambaController;
+import com.eccolimp.cacamba_manager.domain.service.CacambaService;
+
+@WebMvcTest(CacambaController.class)
+class CacambaControllerValidationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    CacambaService cacambaService;
+
+    @Test
+    void deveRetornar400QuandoDadosInvalidos() throws Exception {
+        String json = """
+                {
+                  \"codigo\": \"\",
+                  \"capacidadeM3\": null,
+                  \"status\": \"DISPONIVEL\"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/cacambas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- aplica validações de bean validation em `CacambaDTO`
- cria teste de controller garantindo retorno 400 para dados inválidos

## Testing
- `mvn test` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892324c65488321bcf04410292f0d5c