### PR TITLE
feat: tornar email de relatório configurável

### DIFF
--- a/EMAIL_SETUP.md
+++ b/EMAIL_SETUP.md
@@ -89,9 +89,9 @@ app.notification.email.from-name=Nome da Empresa
 ```
 
 ### **Configurar Email de Destino do Relatório**
-Edite o arquivo `NotificationService.java`:
-```java
-String emailDestino = "gerente@empresa.com"; // Altere aqui
+Defina o email que receberá o relatório semanal:
+```properties
+app.notification.email.report-to=gerente@empresa.com
 ```
 
 ## 📧 Tipos de Email

--- a/src/main/java/com/eccolimp/cacamba_manager/notification/service/NotificationService.java
+++ b/src/main/java/com/eccolimp/cacamba_manager/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.eccolimp.cacamba_manager.notification.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,9 @@ public class NotificationService {
     private final EmailService emailService;
     private final AluguelService aluguelService;
     private final AluguelRepository aluguelRepository;
+
+    @Value("${app.notification.email.report-to}")
+    private String reportToEmail;
 
     /**
      * Envia notificações de vencimento automaticamente
@@ -89,8 +93,8 @@ public class NotificationService {
         
         try {
             // Aqui você pode implementar a lógica para buscar dados do relatório
-            // e enviar para um email específico (ex: gerente@empresa.com)
-            String emailDestino = "minhacacambaon@gmail.com"; // Configurável
+            // e enviar para um email configurado
+            String emailDestino = reportToEmail;
             
             // Dados do relatório (implementar conforme necessário)
             Map<String, Object> dadosRelatorio = gerarDadosRelatorioSemanal();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,4 @@ spring.mail.properties.mail.smtp.writetimeout=5000
 app.notification.email.enabled=true
 app.notification.email.from=${EMAIL_USERNAME:minhacacambaon@gmail.com}
 app.notification.email.from-name=Gerenciador de Caçambas
+app.notification.email.report-to=minhacacambaon@gmail.com


### PR DESCRIPTION
## Summary
- tornar o email de destino do relatório semanal configurável
- documentar propriedade `app.notification.email.report-to`

## Testing
- `mvn -q test` *(falhou: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68923655625c832187ce5241a3c18c04