### PR TITLE
Use Apache Commons Validator for email validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,14 +76,18 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-validator</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>nz.net.ultraq.thymeleaf</groupId>
 			<artifactId>thymeleaf-layout-dialect</artifactId>

--- a/src/main/java/com/eccolimp/cacamba_manager/notification/service/EmailService.java
+++ b/src/main/java/com/eccolimp/cacamba_manager/notification/service/EmailService.java
@@ -10,6 +10,8 @@ import org.thymeleaf.context.Context;
 import com.eccolimp.cacamba_manager.domain.model.Aluguel;
 import com.eccolimp.cacamba_manager.domain.model.Cliente;
 
+import org.apache.commons.validator.routines.EmailValidator;
+
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
     private final TemplateEngine templateEngine;
+    private final EmailValidator emailValidator = EmailValidator.getInstance();
 
     @Value("${app.notification.email.enabled:true}")
     private boolean emailEnabled;
@@ -48,7 +51,7 @@ public class EmailService {
             Cliente cliente = aluguel.getCliente();
             String to = cliente.getContato(); // Assumindo que o contato é o email
             
-            if (!isValidEmail(to)) {
+            if (!emailValidator.isValid(to)) {
                 log.warn("Email inválido para cliente {}: {}", cliente.getNome(), to);
                 return;
             }
@@ -77,7 +80,7 @@ public class EmailService {
             Cliente cliente = aluguel.getCliente();
             String to = cliente.getContato();
             
-            if (!isValidEmail(to)) {
+            if (!emailValidator.isValid(to)) {
                 log.warn("Email inválido para cliente {}: {}", cliente.getNome(), to);
                 return;
             }
@@ -170,7 +173,4 @@ public class EmailService {
         return templateEngine.process("email/relatorio-semanal", context);
     }
 
-    private boolean isValidEmail(String email) {
-        return email != null && email.contains("@") && email.contains(".");
-    }
-} 
+}

--- a/src/test/java/com/eccolimp/cacamba_manager/EmailServiceTest.java
+++ b/src/test/java/com/eccolimp/cacamba_manager/EmailServiceTest.java
@@ -1,0 +1,76 @@
+package com.eccolimp.cacamba_manager;
+
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.eccolimp.cacamba_manager.domain.model.Aluguel;
+import com.eccolimp.cacamba_manager.domain.model.Cacamba;
+import com.eccolimp.cacamba_manager.domain.model.Cliente;
+import com.eccolimp.cacamba_manager.notification.service.EmailService;
+
+import jakarta.mail.internet.MimeMessage;
+
+public class EmailServiceTest {
+
+    private JavaMailSender mailSender;
+    private TemplateEngine templateEngine;
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        mailSender = mock(JavaMailSender.class);
+        templateEngine = mock(TemplateEngine.class);
+        emailService = new EmailService(mailSender, templateEngine);
+        ReflectionTestUtils.setField(emailService, "emailEnabled", true);
+        ReflectionTestUtils.setField(emailService, "fromEmail", "no-reply@exemplo.com");
+        ReflectionTestUtils.setField(emailService, "fromName", "Sistema");
+
+        when(templateEngine.process(anyString(), any(Context.class))).thenReturn("html");
+        when(mailSender.createMimeMessage()).thenReturn(new MimeMessage((jakarta.mail.Session) null));
+    }
+
+    @Test
+    void deveEnviarEmailQuandoEnderecoValido() throws Exception {
+        Aluguel aluguel = criarAluguel("cliente@exemplo.com");
+
+        emailService.enviarNotificacaoVencimento(aluguel, 3);
+
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void naoDeveEnviarEmailQuandoEnderecoInvalido() throws Exception {
+        Aluguel aluguel = criarAluguel("email-invalido");
+
+        emailService.enviarNotificacaoVencimento(aluguel, 3);
+
+        verify(mailSender, never()).send(any(MimeMessage.class));
+    }
+
+    private Aluguel criarAluguel(String email) {
+        Cliente cliente = new Cliente();
+        cliente.setNome("Fulano");
+        cliente.setContato(email);
+
+        Cacamba cacamba = new Cacamba();
+        cacamba.setCodigo("CX-1");
+        cacamba.setCapacidadeM3(5);
+
+        Aluguel aluguel = new Aluguel();
+        aluguel.setId(1L);
+        aluguel.setCliente(cliente);
+        aluguel.setCacamba(cacamba);
+        aluguel.setEndereco("Rua X, 123");
+        aluguel.setDataInicio(LocalDate.now());
+        aluguel.setDataFim(LocalDate.now().plusDays(1));
+        return aluguel;
+    }
+}


### PR DESCRIPTION
## Summary
- Add commons-validator dependency
- Replace custom email check in EmailService with EmailValidator
- Add unit tests for valid and invalid emails

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892bedf19988321861d801841b37992